### PR TITLE
Add JSON formatted output reports to the EDGAR/render plugin

### DIFF
--- a/render/Filing.py
+++ b/render/Filing.py
@@ -323,6 +323,7 @@ class Filing(object):
         self.validatedForEFM = controller.validatedForEFM
         self.reportXmlFormat = 'xml' in controller.reportFormat.casefold()
         self.reportHtmlFormat = 'html' in controller.reportFormat.casefold()
+        self.reportJsonFormat = 'json' in controller.reportFormat.casefold()
         self.fileNamePrefix = 'R'
         if controller.reportZip:
             self.fileNameBase = None

--- a/render/Report.py
+++ b/render/Report.py
@@ -1106,9 +1106,24 @@ class Report(object):
         baseNameBeforeExtension = self.filing.fileNamePrefix + str(self.cube.fileNumber)
         reportSummary.baseNameBeforeExtension = baseNameBeforeExtension
         tree = self.rootETree.getroottree()
+        if self.filing.reportJsonFormat: self.writeJsonFile(baseNameBeforeExtension, tree, reportSummary)
         if self.filing.reportXmlFormat: self.writeXmlFile(baseNameBeforeExtension, tree, reportSummary)
         if self.filing.reportHtmlFormat: self.writeHtmlFile(baseNameBeforeExtension, tree, reportSummary)
 
+    def writeJsonFile(self, baseNameBeforeExtension, tree, reportSummary):
+        import json, xmltodict
+        baseName = (self.filing.rFilePrefix or '') + baseNameBeforeExtension + '.json' + (self.filing.suplSuffix or '')
+        reportSummary.xmlFileName = baseName
+        xmlText = treeToString(tree, xml_declaration=True, encoding='utf-8', pretty_print=True)
+        json_data = json.dumps(xmltodict.parse(xmlText), indent=4)
+
+        if self.filing.reportZip:
+            self.filing.reportZip.writestr(self.filing.zipDir + baseName, json_data)
+            self.controller.renderedFiles.add(baseName)
+        elif self.filing.fileNameBase is not None:
+            self.controller.writeFile(os.path.join(self.filing.fileNameBase, baseName), json_data)
+            self.controller.renderedFiles.add(baseName)
+            
     def writeXmlFile(self, baseNameBeforeExtension, tree, reportSummary):
         baseName = (self.filing.rFilePrefix or '') + baseNameBeforeExtension + '.xml' + (self.filing.suplSuffix or '')
         reportSummary.xmlFileName = baseName

--- a/render/__init__.py
+++ b/render/__init__.py
@@ -242,7 +242,7 @@ def edgarRendererCmdLineOptionExtender(parser, *args, **kwargs):
                       help=_("Type of HTML report...Complete: asPage rendering = True, or Fragment: asPage rendering = False."))
 
     parser.add_option("--reportFormat", dest="reportFormat",
-                      help=_("One of Xml, Html, HtmlAndXml or None."))
+                      help=_("One of Xml, Html, JSON, HtmlAndXml or None."))
 
     parser.add_option("--failFile", dest="failFile", help=_("Relative path and name of fail file. "))
 
@@ -404,7 +404,7 @@ class EdgarRenderer(Cntlr.Cntlr):
 
         # options applicable to rendering in either mode:
         options.renderingService = setProp('renderingService', options.renderingService, rangeList=['Instance', 'Daemon'])
-        options.reportFormat = setProp('reportFormat', options.reportFormat, rangeList=['Html', 'Xml', 'HtmlAndXml', 'None'])
+        options.reportFormat = setProp('reportFormat', options.reportFormat, rangeList=['Html', 'Xml', 'JSON', 'HtmlAndXml', 'None'])
         options.htmlReportFormat = setProp('htmlReportFormat', options.htmlReportFormat, rangeList=['Complete', 'Fragment'])
         options.zipOutputFile = setProp('zipOutputFile', options.zipOutputFile, cs=True)
         options.sourceList = " ".join(setProp('sourceList', options.sourceList, cs=True).split()).split(',')

--- a/render/requirements.txt
+++ b/render/requirements.txt
@@ -1,3 +1,4 @@
 lxml>=4.6.3
 matplotlib>=3.4.2
 openpyxl>=3.0.7
+xmltodict==0.13.0


### PR DESCRIPTION
# Description

This PR adds support to the EDGAR/render plugin for creating JSON-format output reports, in addition to the existing XML and HTML formats.

## Build and test environment

Windows 11

# Open Questions
* This PR relies on the `xmltodict` package. I added this entry to the `requirements.txt` file but was not sure how/if I needed make a corresponding change to the Arelle package too? 

# Example run

```
(.venv) C:\Users\Sam>dir Reports
 Volume in drive C has no label.
 Volume Serial Number is 6659-41BB

 Directory of C:\Users\Sam\Reports

09/24/2024  11:59 AM    <DIR>          .
09/24/2024  11:59 AM    <DIR>          ..
               0 File(s)              0 bytes
               2 Dir(s)  989,171,834,880 bytes free

(.venv) C:\Users\Sam>python \Users\Sam\code\Arelle\arelleCmdLine.py -f https://www.sec.gov/Archives/edgar/data/1804591/000180459124000047/me-20240630_htm.xml -r C:\Users\Sam\Reports --plugins "C:\Users\Sam\Code\EDGAR\render|C:\Users\Sam\Code\EDGAR\validate" --disclosureSystem efm-pragmatic --reportFormat JSON --loglevel warning

(.venv) C:\Users\Sam>dir Reports
 Volume in drive C has no label.
 Volume Serial Number is 6659-41BB

 Directory of C:\Users\Sam\Reports

09/24/2024  11:59 AM    <DIR>          .
09/24/2024  11:59 AM    <DIR>          ..
09/24/2024  11:59 AM            35,804 FilingSummary.htm
09/24/2024  11:59 AM            48,954 FilingSummary.xml
09/24/2024  11:59 AM           124,359 Financial_Report.xlsx
09/24/2024  11:59 AM           258,358 me-20240630_htm.zip
09/24/2024  11:59 AM           158,940 R1.json
09/24/2024  11:59 AM            43,963 R10.json
09/24/2024  11:59 AM            91,876 R11.json
09/24/2024  11:59 AM            15,369 R12.json
09/24/2024  11:59 AM            64,340 R13.json
09/24/2024  11:59 AM            11,123 R14.json
09/24/2024  11:59 AM            35,353 R15.json
09/24/2024  11:59 AM            99,633 R16.json
09/24/2024  11:59 AM            14,982 R17.json
09/24/2024  11:59 AM            16,622 R18.json
09/24/2024  11:59 AM            15,077 R19.json
09/24/2024  11:59 AM           187,455 R2.json
09/24/2024  11:59 AM            22,500 R20.json
09/24/2024  11:59 AM            73,273 R21.json
09/24/2024  11:59 AM            37,134 R22.json
09/24/2024  11:59 AM            11,346 R23.json
09/24/2024  11:59 AM            12,394 R24.json
09/24/2024  11:59 AM             8,856 R25.json
09/24/2024  11:59 AM            13,646 R26.json
09/24/2024  11:59 AM            20,974 R27.json
09/24/2024  11:59 AM            15,020 R28.json
09/24/2024  11:59 AM            62,913 R29.json
09/24/2024  11:59 AM           141,592 R3.json
09/24/2024  11:59 AM            21,211 R30.json
09/24/2024  11:59 AM            87,682 R31.json
09/24/2024  11:59 AM            57,971 R32.json
09/24/2024  11:59 AM            29,069 R33.json
09/24/2024  11:59 AM           113,495 R34.json
09/24/2024  11:59 AM            13,086 R35.json
09/24/2024  11:59 AM            15,647 R36.json
09/24/2024  11:59 AM            13,230 R37.json
09/24/2024  11:59 AM            65,991 R38.json
09/24/2024  11:59 AM            37,848 R39.json
09/24/2024  11:59 AM           222,140 R4.json
09/24/2024  11:59 AM            27,798 R40.json
09/24/2024  11:59 AM           251,358 R41.json
09/24/2024  11:59 AM            94,041 R42.json
09/24/2024  11:59 AM           603,533 R43.json
09/24/2024  11:59 AM           180,213 R44.json
09/24/2024  11:59 AM           143,914 R45.json
09/24/2024  11:59 AM           198,606 R46.json
09/24/2024  11:59 AM             8,662 R47.json
09/24/2024  11:59 AM           173,422 R48.json
09/24/2024  11:59 AM            83,147 R49.json
09/24/2024  11:59 AM            55,468 R5.json
09/24/2024  11:59 AM            31,348 R50.json
09/24/2024  11:59 AM           123,188 R51.json
09/24/2024  11:59 AM            11,225 R52.json
09/24/2024  11:59 AM            29,557 R53.json
09/24/2024  11:59 AM            90,853 R54.json
09/24/2024  11:59 AM            54,668 R55.json
09/24/2024  11:59 AM            19,193 R56.json
09/24/2024  11:59 AM            20,356 R57.json
09/24/2024  11:59 AM           213,787 R58.json
09/24/2024  11:59 AM            40,373 R59.json
09/24/2024  11:59 AM           358,420 R6.json
09/24/2024  11:59 AM            42,141 R60.json
09/24/2024  11:59 AM            42,791 R61.json
09/24/2024  11:59 AM            28,140 R62.json
09/24/2024  11:59 AM            47,591 R63.json
09/24/2024  11:59 AM            35,238 R64.json
09/24/2024  11:59 AM            74,370 R65.json
09/24/2024  11:59 AM           238,510 R66.json
09/24/2024  11:59 AM            76,006 R67.json
09/24/2024  11:59 AM         1,202,860 R68.json
09/24/2024  11:59 AM           101,287 R69.json
09/24/2024  11:59 AM           203,159 R7.json
09/24/2024  11:59 AM            81,930 R70.json
09/24/2024  11:59 AM            54,907 R71.json
09/24/2024  11:59 AM           120,281 R72.json
09/24/2024  11:59 AM            11,985 R73.json
09/24/2024  11:59 AM           178,498 R74.json
09/24/2024  11:59 AM            75,341 R75.json
09/24/2024  11:59 AM            23,928 R76.json
09/24/2024  11:59 AM            14,159 R77.json
09/24/2024  11:59 AM            28,127 R78.json
09/24/2024  11:59 AM           179,247 R79.json
09/24/2024  11:59 AM            50,720 R8.json
09/24/2024  11:59 AM            12,896 R9.json
09/24/2024  11:59 AM             2,833 report.css
09/24/2024  11:59 AM               978 Show.js
              85 File(s)      8,060,279 bytes
               2 Dir(s)  995,430,834,176 bytes free
```

