### PR TITLE
Edgar24.3.1.u3 preview

### DIFF
--- a/validate/resources/edgartaxonomies/edgartaxonomies-24-3.xml
+++ b/validate/resources/edgartaxonomies/edgartaxonomies-24-3.xml
@@ -160,6 +160,20 @@ are not subject to domestic copyright protection. 17 U.S.C. 105.
         <Namespace>http://xbrl.org/2020/extensible-enumerations-2.0</Namespace>
         <Prefix>enum2</Prefix>
     </Loc>
+    <!-- 
+        keeping http version of 2020 extensible-enumerations-2.0.xsd for backward compatibility.
+        IFRS used the http version up to 8/29/2024 and then replaced it with the https version.
+    -->
+    <Loc>
+        <Family>IFRS</Family>
+        <Version>2024</Version>
+        <Href>http://xbrl.org/2020/extensible-enumerations-2.0.xsd</Href>
+        <AttType>SCH</AttType>
+        <FileTypeName>Schema</FileTypeName>
+        <Elements>0</Elements>
+        <Namespace>http://xbrl.org/2020/extensible-enumerations-2.0</Namespace>
+        <Prefix>enum2</Prefix>
+    </Loc>
     <!-- SBS 2024 -->
     <Loc>
         <Family>SBS</Family>

--- a/validate/resources/edgartaxonomies/edgartaxonomies-24-3.xml
+++ b/validate/resources/edgartaxonomies/edgartaxonomies-24-3.xml
@@ -153,7 +153,7 @@ are not subject to domestic copyright protection. 17 U.S.C. 105.
     <Loc>
         <Family>IFRS</Family>
         <Version>2024</Version>
-        <Href>http://xbrl.org/2020/extensible-enumerations-2.0.xsd</Href>
+        <Href>https://xbrl.org/2020/extensible-enumerations-2.0.xsd</Href>
         <AttType>SCH</AttType>
         <FileTypeName>Schema</FileTypeName>
         <Elements>0</Elements>

--- a/validate/resources/edgartaxonomies/edgartaxonomies-all-years.xml
+++ b/validate/resources/edgartaxonomies/edgartaxonomies-all-years.xml
@@ -160,7 +160,20 @@ are not subject to domestic copyright protection. 17 U.S.C. 105.
         <Namespace>http://xbrl.org/2020/extensible-enumerations-2.0</Namespace>
         <Prefix>enum2</Prefix>
     </Loc>
-
+    <!-- 
+        keeping http version of 2020 extensible-enumerations-2.0.xsd for backward compatibility.
+        IFRS used the http version up to 8/29/2024 and then replaced it with the https version.
+    -->
+    <Loc>
+        <Family>IFRS</Family>
+        <Version>2024</Version>
+        <Href>http://xbrl.org/2020/extensible-enumerations-2.0.xsd</Href>
+        <AttType>SCH</AttType>
+        <FileTypeName>Schema</FileTypeName>
+        <Elements>0</Elements>
+        <Namespace>http://xbrl.org/2020/extensible-enumerations-2.0</Namespace>
+        <Prefix>enum2</Prefix>
+    </Loc>
 	<!-- SBS 2024 -->
 	<Loc>
         <Family>SBS</Family>

--- a/validate/resources/edgartaxonomies/edgartaxonomies-all-years.xml
+++ b/validate/resources/edgartaxonomies/edgartaxonomies-all-years.xml
@@ -153,7 +153,7 @@ are not subject to domestic copyright protection. 17 U.S.C. 105.
     <Loc>
         <Family>IFRS</Family>
         <Version>2024</Version>
-        <Href>http://xbrl.org/2020/extensible-enumerations-2.0.xsd</Href>
+        <Href>https://xbrl.org/2020/extensible-enumerations-2.0.xsd</Href>
         <AttType>SCH</AttType>
         <FileTypeName>Schema</FileTypeName>
         <Elements>0</Elements>


### PR DESCRIPTION
Add IFRS href update to https://xbrl.org/2020/extensible-enumerations-2.0.xsd for edgartaxonomies-24.3 and all years, planned for production 2024-10-30.

(Note that submissions to SEC prior to 10-30 should locally validate with prior IFRS xsd.)