### PR TITLE
Use raw URL for downloading XULE map

### DIFF
--- a/validate/XuleInterface.py
+++ b/validate/XuleInterface.py
@@ -54,7 +54,7 @@ _xule_resources_dir = os.path.join(os.path.dirname(__file__), "resources", "xule
 _xule_resources_dir_for_json = json.dumps(_xule_resources_dir + os.sep)[1:-1]
 _plugin_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 _rule_set_map_name = os.path.join(_xule_resources_dir, "edgarRulesetMap.json")
-_latest_map_name = 'https://github.com/Arelle/EDGAR/tree/master/validate/resources/xule/edgarRulesetMapOnline.json'
+_latest_map_name = 'https://github.com/Arelle/EDGAR/raw/master/validate/resources/xule/edgarRulesetMapOnline.json'
 xule_error_code_pattern = re.compile(r"DQC\.|xule\.")
 
 """Do not change anything below this line."""


### PR DESCRIPTION
Resolves google group issue [eUctQuWJz_M](https://groups.google.com/g/arelle-users/c/eUctQuWJz_M)

The tree URL returns HTML content, the raw URL returns the JSON content that's required.