### PR TITLE
Move first IXDS encountered to first position rather than last

### DIFF
--- a/validate/__init__.py
+++ b/validate/__init__.py
@@ -406,7 +406,9 @@ def filingStart(cntlr, options, filesource, entrypointFiles, sourceZipStream=Non
             ixdsIndex = primaryIndex = -1
             for i, ep in enumerate(entrypointFiles):
                 if "ixds" in ep:
-                    ixdsIndex = i
+                    # select index of first IXDS encountered
+                    if ixdsIndex < 0:
+                        ixdsIndex = i
                     for i, ixdsEntry in enumerate(ep["ixds"]):
                         submissionType = ixdsEntry.get("submissionType")
                         attachmentDocumentType = ixdsEntry.get("attachmentDocumentType")


### PR DESCRIPTION
The current logic moves the _last_ IXDS discovered into the significant first position, which may be overriding the user's intentional placement of some other IXDS entry point in that first position.

Instead, select the first encountered IXDS as the primary entry point, moving only if it isn't already in the first overall position.