### PR TITLE
EDGAR Release 25.1.3.u2

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 __pluginInfo__ = {
     'name': 'EDGAR',
     'version': '3.25.1',
-    'description': "This plug-in implements U.S. SEC Edgar Renderer. Arelle version at SEC: 2.36.18 ",
+    'description': "This plug-in implements U.S. SEC Edgar Renderer. Arelle version at SEC: 2.37.7 ",
     'license': 'Apache-2',
     'author': 'U.S. SEC Employees and Mark V Systems Limited',
     'copyright': '(c) Portions by SEC Employees not subject to domestic copyright, otherwise (c) Copyright 2015 Mark V Systems Limited, All rights reserved.',

--- a/readme.md
+++ b/readme.md
@@ -4,10 +4,12 @@
 The EDGAR plugin, developed and maintained by the staff of the U.S. Securities and Exchange Commission (SEC), is designed to provide traditional and inline XBRL viewers for SEC filings. It also integrates with and extends the EFM Validation plugin, offering EFM validation for SEC filings. For end-user support, please contact the SEC directly at: StructuredData@sec.gov.
 
 ## Arelle Version
-The current version of Arelle in use at the SEC is: **2.36.18**
+The current version of Arelle in use at the SEC is: **2.37.7**
 
 ## Installation
-The EDGAR plugin requires the xule plugin to be present under the Arelle plugin directory. You can clone the xule repository into the plugin directory. The current xule implementation used at the SEC is available [here](https://github.com/hermfischer-wf/xule/tree/HF-save-reload-constants).
+The EDGAR plugin requires the xule plugin to be present under the Arelle plugin directory. You can clone the xule repository into the plugin directory. 
+
+The current version of xule in use at the SEC is: **30047**
 
 ## XULE & DQCRT rules
 The SEC will begin using the XULE DQCRT rule implementation for filings using us-gaap/2025 and newer, otherwise the Python implemented rules will run for us-gaap/2023-4 filings. When XULE is integrated with EDGAR the Validate.Finally plugin call is disabled so that EDGAR can run XULE in its workflow with multiple IXDSes and multiple passes when redaction is involved. 

--- a/render/__init__.py
+++ b/render/__init__.py
@@ -345,7 +345,7 @@ class EdgarRenderer(Cntlr.Cntlr):
         self.defaultValueDict['deliveryFolder'] = 'Delivery'
         self.defaultValueDict['debugMode'] = str(False)
         self.defaultValueDict['errorsFolder'] = 'Errors'
-        self.defaultValueDict['excelXslt'] = 'InstanceReport_XmlWorkbook.xslt'
+        self.defaultValueDict['excelXslt'] = None # starting EDGAR release 25.1.3.u2 we don't want to generate Financial_Report.xlsx.
         self.defaultValueDict['failFile'] = 'errorLog.log'
         self.defaultValueDict['filingsFolder'] = 'Filings'
         self.defaultValueDict['htmlReportFormat'] = 'Complete'
@@ -526,6 +526,7 @@ class EdgarRenderer(Cntlr.Cntlr):
         # Excel XSLT is optional, but do report if you can't find it.
         # setResourceFile('excelXslt', options.excelXslt, 'INVALID_CONFIG_EXCELXSLT')
         # if options.excelXslt is "True" from web interface, it has no no string value, e.g., &excelXslt (looks like True here)
+        # starting EDGAR release 25.1.3.u2 we don't want to generate Financial_Report.xlsx but will allow if --excelXslt is passed in.
         options.excelXslt = setResourceFile('excelXslt', "" if options.excelXslt == True else options.excelXslt, "Cannot find excel xslt {}")
 
         # logMessageTextFile is optional resources file for messages text (SEC format)
@@ -1833,7 +1834,7 @@ def edgarRendererGuiRun(cntlr, modelXbrl, *args, **kwargs):
             summaryXslt=_summaryXslt,
             summaryXsltDissem=parameters["summaryXslt"][1] if "summaryXslt" in parameters else None,
             renderingLogsXslt=('RenderingLogs.xslt', None)[_combinedReports],
-            excelXslt=('InstanceReport_XmlWorkbook.xslt', None)[_combinedReports],
+            excelXslt=None, # starting EDGAR release 25.1.3.u2 we don't want to generate Financial_Report.xlsx.
             logMessageTextFile=None,
             logFile=None,  # from cntlrCmdLine but need to simulate for GUI operation
             labelLang=cntlr.labelLang,  # emulate cmd line labelLang
@@ -2094,7 +2095,7 @@ def edgarRendererRemoveRedlining(modelDocument, *args, **kwargs):
 __pluginInfo__ = {
     'name': 'Edgar Renderer',
     'version': VERSION,
-    'description': "This plug-in implements U.S. SEC Edgar Renderer.  Arelle version at SEC: 2.36.18 ",
+    'description': "This plug-in implements U.S. SEC Edgar Renderer.  Arelle version at SEC: 2.37.7 ",
     'license': 'Apache-2',
     'author': 'U.S. SEC Employees and Mark V Systems Limited',
     'copyright': '(c) Portions by SEC Employees not subject to domestic copyright, otherwise (c) Copyright 2015 Mark V Systems Limited, All rights reserved.',

--- a/render/conf/config_builtin_defaults.xml
+++ b/render/conf/config_builtin_defaults.xml
@@ -8,7 +8,7 @@
   <processingFolder>Processing</processingFolder>
   <reportsFolder>Reports</reportsFolder>
   <resourcesFolder>..\\resources</resourcesFolder>
-  <excelXslt>InstanceReport_XmlWorkbook.xslt</excelXslt>
+  <excelXslt />
   <reportXslt>InstanceReport.xslt</reportXslt>
   <renderingLogsXslt>RenderingLogs.xslt</renderingLogsXslt>
   <summaryXslt>Summarize.xslt</summaryXslt>

--- a/render/conf/config_for_daemon.xml
+++ b/render/conf/config_for_daemon.xml
@@ -30,7 +30,7 @@
   <!-- Optional, transform FilingSummary.xml into FilingSummary.htm -->
   <summaryXslt>Summarize.xslt</summaryXslt>
   <!-- Optional transform one r.xml into Excel 2007 xlsx output, or empty if no Excel output desired -->
-  <excelXslt>InstanceReport_XmlWorkbook.xslt</excelXslt>
+  <excelXslt />
   <!--  Optional to transform rendering logs for browser reference (when browsers may no longer have XSLT Processors) -->
   <renderingLogsXslt>RenderingLogs.xslt</renderingLogsXslt>
   <!--  Optional to transform rendering logs in browser (if False, logs are transformed on server and htm file provided to browser) -->

--- a/render/resources/arelleMessagesText.xml
+++ b/render/resources/arelleMessagesText.xml
@@ -1274,8 +1274,8 @@ Amount rxp:A missing for reporting currency and matching 12 months preceding dei
 <message code="EFM.6.07.03"
          level="error"
          module="ValidateFilingDTS.py" line="95"
-         args="schema targetNamespace targetNamespaceAuthority">
-[fs-0703-Extension-Has-Standard-Namespace-Authority]  The target namespace, {targetNamespace} cannot have the same authority ({targetNamespaceAuthority}) as a standard taxonomy, in {schema}.  Please change your target namespace.
+         args="schema targetNamespace targetNamespaceEffectiveAuthority">
+[fs-0703-Extension-Has-Standard-Namespace-Authority]  The target namespace, {targetNamespace} cannot have the same effective authority ({targetNamespaceEffectiveAuthority}) as a standard taxonomy, in {schema}.  Please change your target namespace.
 
 </message>
 

--- a/render/svc_template/BuilderService.xml
+++ b/render/svc_template/BuilderService.xml
@@ -30,7 +30,7 @@
   <!-- Optional, transform FilingSummary.xml into FilingSummary.htm -->
   <summaryXslt>Summarize.xslt</summaryXslt>
   <!-- Optional transform output xml into Excel 2007 xlsx sheet, or empty if no Excel output desired -->
-  <excelXslt>InstanceReport_XmlWorkbook.xslt</excelXslt>
+  <excelXslt />
   <!-- Application settings that used by RE to manage the processing of XBRL filings: -->
   <!-- renderingService: {Instance: one time rendering || Daemon: background processing} -->
   <renderingService>Daemon</renderingService>

--- a/render/svc_template/PreviewerService.xml
+++ b/render/svc_template/PreviewerService.xml
@@ -30,7 +30,7 @@
   <!-- Optional, transform FilingSummary.xml into FilingSummary.htm -->
   <summaryXslt/>
   <!-- Optional transform output xml into Excel 2007 xlsx sheet, or empty if no Excel output desired -->
-  <excelXslt>InstanceReport_XmlWorkbook.xslt</excelXslt>
+  <excelXslt />
   <!-- Application settings that used by RE to manage the processing of XBRL filings: -->
   <!-- renderingService: {Instance: one time rendering || Daemon: background processing} -->
   <renderingService>Daemon</renderingService>

--- a/render/svc_template/ViewerService.xml
+++ b/render/svc_template/ViewerService.xml
@@ -30,7 +30,7 @@
   <!-- Optional, transform FilingSummary.xml into FilingSummary.htm -->
   <summaryXslt/>
   <!-- Optional transform output xml into Excel 2007 xlsx sheet, or empty if no Excel output desired -->
-  <excelXslt>InstanceReport_XmlWorkbook.xslt</excelXslt>
+  <excelXslt />
   <!-- Application settings that used by RE to manage the processing of XBRL filings: -->
   <!-- renderingService: {Instance: one time rendering || Daemon: background processing} -->
   <renderingService>Daemon</renderingService>

--- a/validate/DTS.py
+++ b/validate/DTS.py
@@ -7,6 +7,7 @@ from arelle import (ModelDocument, XmlUtil, XbrlConst, UrlUtil)
 from arelle.ModelObject import ModelObject
 from arelle.ModelDtsObject import ModelConcept
 from .Consts import standardNamespacesPattern
+from .Util import getEffectiveAuthority
 
 targetNamespaceDatePattern = None
 efmFilenamePattern = None
@@ -104,13 +105,15 @@ def checkFilingDTS(val, modelDocument, isEFM, isGFM, visited):
         # check schema contents types
         # 6.7.3 check namespace for standard authority
         targetNamespaceAuthority = UrlUtil.authority(modelDocument.targetNamespace)
-        if targetNamespaceAuthority in val.disclosureSystem.standardAuthorities:
+        targetNamespaceEffectiveAuthority = getEffectiveAuthority(modelDocument.targetNamespace)
+        standardEffectiveAuthorities = {getEffectiveAuthority(stdAuth) for stdAuth in val.disclosureSystem.standardAuthorities}
+        if targetNamespaceEffectiveAuthority in standardEffectiveAuthorities:
             val.modelXbrl.error(("EFM.6.07.03", "GFM.1.03.03"),
-                _("The target namespace, %(targetNamespace)s cannot have the same authority (%(targetNamespaceAuthority)s) as a standard "
+                _("The target namespace, %(targetNamespace)s cannot have the same effective authority (%(targetNamespaceEffectiveAuthority)s) as a standard "
                   "taxonomy, in %(schema)s.  Please change your target namespace."),
                 edgarCode="fs-0703-Extension-Has-Standard-Namespace-Authority",
                 modelObject=modelDocument, schema=modelDocument.basename, targetNamespace=modelDocument.targetNamespace,
-                targetNamespaceAuthority=UrlUtil.authority(modelDocument.targetNamespace, includeScheme=False))
+                targetNamespaceEffectiveAuthority=targetNamespaceEffectiveAuthority)
 
         # 6.7.4 check namespace format
         if modelDocument.targetNamespace is None or not modelDocument.targetNamespace.startswith("http://"):

--- a/validate/Util.py
+++ b/validate/Util.py
@@ -7,7 +7,7 @@ from decimal import Decimal
 from collections import defaultdict, OrderedDict
 from arelle.FileSource import openFileStream, openFileSource, saveFile # only needed if building a cached file
 from arelle.ModelValue import qname, dateTime, DATE
-from arelle import XbrlConst
+from arelle import XbrlConst, UrlUtil
 from arelle.PythonUtil import attrdict, flattenSequence, pyObjectSize, OrderedSet
 from arelle.ValidateXbrlCalcs import inferredDecimals, floatINF
 from arelle.XmlValidateConst import VALID
@@ -36,6 +36,19 @@ def abbreviatedNamespace(namespaceURI, pattern=WITHYEAR):
         return {WITHYEAR: "{}/{}", WILD: "{}/*", NOYEAR: "{}"
                 }[pattern].format(match.group(2) or match.group(6), match.group(3) or match.group(5))
     return None
+
+def getEffectiveAuthority(url: str) -> str:
+    # the effective authority of a URI consists of the last part of the URI between the // 
+    # and the first / and containing at most one dot.
+    if url:
+        if url.lower().startswith("urn:"):
+            # UrlUtil.authority does not handle urn well
+            # effective authority for a urn is the NID
+            # part between the first 2 colons
+            return url.split(":")[1]
+        authority = UrlUtil.authority(url, includeScheme=False)
+        return ".".join(authority.split(".")[-2:])
+    return url
 
 def usgaapYear(modelXbrl):
     for d in modelXbrl.urlDocs.values():


### PR DESCRIPTION
EDGAR Release 25.1.3.u2 scheduled for deployment on Friday May 16th, 2025.
**Changes**

1. The EDGAR render plugin will no longer generate the Financial_Report.xlsx. Users may still generated this document via the command line by using the --excelXslt option and passing the document available under render\resources\InstanceReport_XmlWorkbook.xslt.
2. The target namespace, cannot have the same effective authority as a standard taxonomy. eg. sec.gov is not allowed.