### PR TITLE
Replace xule locating code with plugin import

### DIFF
--- a/validate/XuleInterface.py
+++ b/validate/XuleInterface.py
@@ -292,7 +292,7 @@ def getXulePlugin(cntlr):
     """
     global _xule_plugin_info, _incompatible_plugin, xulePluginDoesNotExist
     if _xule_plugin_info is None and not xulePluginDoesNotExist:
-        for plugin_name, plugin_info in PluginManager.modulePluginInfos.items():
+        for plugin_info in PluginManager.modulePluginInfos.values():
             moduleUrl = plugin_info.get('moduleURL')
             if moduleUrl == 'xule':
                 _xule_plugin_info = plugin_info
@@ -300,15 +300,6 @@ def getXulePlugin(cntlr):
                 _incompatible_plugin = moduleUrl
                 cntlr.addToLog(_("EDGAR is not compatible with the DQC.py plugin, please remove the DQC.py plugin.  The EDGAR plugin directly manages running of to run DQC rules."),
                                messageCode="arelle.incompatibleRulePlugin")
-        if _xule_plugin_info is None:
-            # attempt to find xule plugi
-            for path, childDirs, files in os.walk(_plugin_dir):
-                if path.endswith(os.sep + "xule") and childDirs in ([], ["__pycache__"]) and "__init__.py" in files:
-                    _xule_plugin_info = PluginManager.moduleModuleInfo(moduleURL=path)
-                    PluginManager.loadModule(_xule_plugin_info)
-                    PluginManager.pluginConfigChanged = False # don't save this change
-                    _xule_plugin_info = PluginManager.modulePluginInfos[_xule_plugin_info["name"]]
-                    break
     if _xule_plugin_info is None and not xulePluginDoesNotExist:
         cntlr.addToLog(_("Xule plugin is not loaded. Xule plugin is required to run DQC rules. This plugin should be automatically loaded."),
                        messageCode="arelle.xulePluginNotLoaded")

--- a/validate/__init__.py
+++ b/validate/__init__.py
@@ -947,7 +947,7 @@ __pluginInfo__ = {
     'version': '1.25.2', # SEC EDGAR release 25.2
     'description': '''EFM Validation.''',
     'license': 'Apache-2',
-    'import': ('EDGAR/transform',), # SEC inline can use SEC transformations
+    'import': ('EDGAR/transform', 'xule'), # SEC inline can use SEC transformations
     'author': authorLabel,
     'copyright': copyrightLabel,
     'aliases': ('validate/EFM', ),


### PR DESCRIPTION
As of Arelle 2.37.58 the plugin manager is able to locate and load plugin info imports even if the plugin to load isn't located at the top level of the `arelle/plugin` directory. The EDGAR/validate dependency on xule will work even if the entire xule repo is cloned into the plugin directory (`arelle/plugin/xule/plugin/xule/__init__.py` instead of `arelle/plugin/xule/__init__.py`).

@freddym56 